### PR TITLE
Fix pronunciation typo across services and controller

### DIFF
--- a/LinguaRise/LinguaRise.Api/Controllers/Lesson/LessonController.cs
+++ b/LinguaRise/LinguaRise.Api/Controllers/Lesson/LessonController.cs
@@ -49,7 +49,7 @@ namespace LinguaRise.Api.Controllers.Lesson
 
         [HttpPost("evaluate-speech")]
         [Consumes("multipart/form-data")]
-        public async Task<ActionResult<PronunciationResultDTO>> EvaluatePronounciation([FromForm] EvaluateSpeechRequest request)
+        public async Task<ActionResult<PronunciationResultDTO>> EvaluatePronunciation([FromForm] EvaluateSpeechRequest request)
         {
             if (request.AudioFile == null || request.AudioFile.Length == 0)
                 return BadRequest("No audio file");
@@ -59,7 +59,7 @@ namespace LinguaRise.Api.Controllers.Lesson
 
             try
             {
-                result = await _lessonService.EvaluatePronounciationAsync(audioStream, request.WordId, request.LanguageId, request.LessonId);
+                result = await _lessonService.EvaluatePronunciationAsync(audioStream, request.WordId, request.LanguageId, request.LessonId);
             }
             catch (Exception ex)
             {

--- a/LinguaRise/LinguaRise.Services/Interfaces/ILessonService.cs
+++ b/LinguaRise/LinguaRise.Services/Interfaces/ILessonService.cs
@@ -9,7 +9,7 @@ namespace LinguaRise.Services.Interfaces
         Task<LessonDTO> GetLessonAsync(int id);
         Task CreateLessonAsync(LessonDTO lesson);
         Task<SpeechResponseDTO> GetLessonContentSpeech(int categoryId, int languageId);
-        Task<PronunciationResultDTO> EvaluatePronounciationAsync(Stream audioStream, int wordId, int languageId, int lessonId);
+        Task<PronunciationResultDTO> EvaluatePronunciationAsync(Stream audioStream, int wordId, int languageId, int lessonId);
         Task<LessonSummaryDTO> GetLessonSummaryAsync(int lessonId, int categoryId);
     }
 }

--- a/LinguaRise/LinguaRise.Services/Interfaces/ISpeechService.cs
+++ b/LinguaRise/LinguaRise.Services/Interfaces/ISpeechService.cs
@@ -6,5 +6,5 @@ namespace LinguaRise.Services.Interfaces;
 public interface ISpeechService
 {
     Task<SpeechResponseDTO> SynthesizeAsync(int categoryId, int courseLanguageId);
-    Task<PronunciationResultDTO> EvaluatePronounciationAsync(Stream audioStream, Language language, int wordId);
+    Task<PronunciationResultDTO> EvaluatePronunciationAsync(Stream audioStream, Language language, int wordId);
 }

--- a/LinguaRise/LinguaRise.Services/Lesson/LessonService.cs
+++ b/LinguaRise/LinguaRise.Services/Lesson/LessonService.cs
@@ -93,10 +93,10 @@ public class LessonService : ILessonService
         return response;
     }
 
-    public async Task<PronunciationResultDTO> EvaluatePronounciationAsync(Stream audioStream, int wordId, int languageId, int lessonId)
+    public async Task<PronunciationResultDTO> EvaluatePronunciationAsync(Stream audioStream, int wordId, int languageId, int lessonId)
     {
         var language = await _languageRepository.GetAsync(languageId);
-        var response = await _speechService.EvaluatePronounciationAsync(audioStream, language, wordId);
+        var response = await _speechService.EvaluatePronunciationAsync(audioStream, language, wordId);
         if (response.IsCorrect)
         {
             var lesson = await _lessonRepository.GetAsync(lessonId);

--- a/LinguaRise/LinguaRise.Services/SpeechService/SpeechService.cs
+++ b/LinguaRise/LinguaRise.Services/SpeechService/SpeechService.cs
@@ -72,7 +72,7 @@ public class SpeechService : ISpeechService
         return new SpeechResponseDTO { Items = items };
     }
 
-    public async Task<PronunciationResultDTO> EvaluatePronounciationAsync(Stream audioStream, Language language, int wordId)
+    public async Task<PronunciationResultDTO> EvaluatePronunciationAsync(Stream audioStream, Language language, int wordId)
     {
         var translatedSentence = await _wordRepository.GetTranslatedWord(wordId, language.Code);
         if (string.IsNullOrWhiteSpace(translatedSentence))


### PR DESCRIPTION
## Summary
- fix misspelling `Pronounciation` → `Pronunciation` in service interfaces and implementations
- update controller to use corrected method name

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684196672fe88328abc4ae27f7b9bb5e